### PR TITLE
Bugfix/black 19.3b0 compat

### DIFF
--- a/blackcellmagic.py
+++ b/blackcellmagic.py
@@ -38,12 +38,11 @@ class FormattingMagic(Magics):
         line_length = args.line_length
         if cell:
             try:
-                formatted = format_str(src_contents=cell, line_length=line_length)
-            except TypeError:
                 from black import FileMode
-                mode = FileMode()
-                mode.line_length = line_length
+                mode = FileMode(line_length=line_length)
                 formatted = format_str(src_contents=cell, mode=mode)
+            except TypeError:
+                formatted = format_str(src_contents=cell, line_length=line_length)
             if formatted and formatted[-1] == "\n":
                     formatted = formatted[:-1]
             self.shell.set_next_input(formatted, replace=True)

--- a/blackcellmagic.py
+++ b/blackcellmagic.py
@@ -38,15 +38,15 @@ class FormattingMagic(Magics):
         line_length = args.line_length
         if cell:
             try:
-                formated = format_str(src_contents=cell, line_length=line_length)
+                formatted = format_str(src_contents=cell, line_length=line_length)
             except TypeError:
                 from black import FileMode
                 mode = FileMode()
                 mode.line_length = line_length
-                formated = format_str(src_contents=cell, mode=mode)
-            if formated and formated[-1] == "\n":
-                    formated = formated[:-1]
-            self.shell.set_next_input(formated, replace=True)
+                formatted = format_str(src_contents=cell, mode=mode)
+            if formatted and formatted[-1] == "\n":
+                    formatted = formatted[:-1]
+            self.shell.set_next_input(formatted, replace=True)
 
 
 def load_ipython_extension(ipython):

--- a/blackcellmagic.py
+++ b/blackcellmagic.py
@@ -37,7 +37,13 @@ class FormattingMagic(Magics):
         args = magic_arguments.parse_argstring(self.black, line)
         line_length = args.line_length
         if cell:
-            formated = format_str(src_contents=cell, line_length=line_length)
+            try:
+                formated = format_str(src_contents=cell, line_length=line_length)
+            except TypeError:
+                from black import FileMode
+                mode = FileMode()
+                mode.line_length = line_length
+                formated = format_str(src_contents=cell, mode=mode)
             if formated and formated[-1] == "\n":
                     formated = formated[:-1]
             self.shell.set_next_input(formated, replace=True)


### PR DESCRIPTION
When having installed the latest [black](https://github.com/ambv/black) version (19.3b0), one runs into the following error:
`TypeError: format_str() got an unexpected keyword argument 'line_length'`
because the `line_length` argument has been removed from the format_str method:
https://github.com/ambv/black/blob/a2f6706a1ea026cbe0e7d83caffa6c13c463bfe1/black.py#L664

This fixes the issue.